### PR TITLE
Mask long body params in logs

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/api/core/RestClient.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/api/core/RestClient.java
@@ -9,6 +9,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
+import static timofeyqa.rococo.utils.LogUtils.maskLongParams;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.CookieManager;
@@ -46,7 +48,9 @@ public abstract class RestClient implements RequestExecutor {
             }
         }
 
-        builder.addNetworkInterceptor(new HttpLoggingInterceptor().setLevel(level));
+        builder.addNetworkInterceptor(new HttpLoggingInterceptor(
+                message -> System.out.println(maskLongParams(message))
+        ).setLevel(level));
         builder.addNetworkInterceptor(
                 new AllureOkHttp3()
                         .setRequestTemplate("http-request.ftl")

--- a/rococo-autotest/src/test/java/timofeyqa/rococo/utils/GrpcConsoleInterceptor.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/utils/GrpcConsoleInterceptor.java
@@ -5,6 +5,8 @@ import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.*;
 
+import static timofeyqa.rococo.utils.LogUtils.maskLongParams;
+
 @SuppressWarnings("unchecked")
 public class GrpcConsoleInterceptor implements ClientInterceptor {
 
@@ -19,7 +21,8 @@ public class GrpcConsoleInterceptor implements ClientInterceptor {
             @Override
             public void sendMessage(Object message) {
                 try {
-                    System.out.println("REQUEST: "+printer.print((MessageOrBuilder) message));
+                    String json = printer.print((MessageOrBuilder) message);
+                    System.out.println("REQUEST: " + maskLongParams(json));
                 } catch (InvalidProtocolBufferException e) {
                     throw new RuntimeException(e);
                 }
@@ -32,7 +35,8 @@ public class GrpcConsoleInterceptor implements ClientInterceptor {
                     @Override
                     public void onMessage(Object message) {
                         try {
-                            System.out.println("RESPONSE: " + printer.print((MessageOrBuilder) message));
+                            String json = printer.print((MessageOrBuilder) message);
+                            System.out.println("RESPONSE: " + maskLongParams(json));
                         } catch (InvalidProtocolBufferException e) {
                             throw new RuntimeException(e);
                         }

--- a/rococo-autotest/src/test/java/timofeyqa/rococo/utils/LogUtils.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/utils/LogUtils.java
@@ -1,0 +1,62 @@
+package timofeyqa.rococo.utils;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public final class LogUtils {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int MAX_LENGTH = 2010;
+
+    private LogUtils() {
+    }
+
+    public static String maskLongParams(String body) {
+        if (body == null || body.isEmpty()) {
+            return body;
+        }
+        try {
+            JsonNode node = MAPPER.readTree(body);
+            if (maskNode(node)) {
+                return MAPPER.writeValueAsString(node);
+            }
+            return body;
+        } catch (Exception e) {
+            return body.length() > MAX_LENGTH ? "<long_param>" : body;
+        }
+    }
+
+    private static boolean maskNode(JsonNode node) {
+        boolean modified = false;
+        if (node.isObject()) {
+            ObjectNode obj = (ObjectNode) node;
+            Iterator<Map.Entry<String, JsonNode>> fields = obj.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                JsonNode value = entry.getValue();
+                if (value.isTextual() && value.asText().length() > MAX_LENGTH) {
+                    obj.put(entry.getKey(), "<long_param>");
+                    modified = true;
+                } else if (maskNode(value)) {
+                    modified = true;
+                }
+            }
+        } else if (node.isArray()) {
+            ArrayNode arr = (ArrayNode) node;
+            for (int i = 0; i < arr.size(); i++) {
+                JsonNode value = arr.get(i);
+                if (value.isTextual() && value.asText().length() > MAX_LENGTH) {
+                    arr.set(i, TextNode.valueOf("<long_param>"));
+                    modified = true;
+                } else if (maskNode(value)) {
+                    modified = true;
+                }
+            }
+        }
+        return modified;
+    }
+}


### PR DESCRIPTION
## Summary
- add utility to mask long request/response values
- use masking in REST and gRPC logging interceptors

## Testing
- `gradle :rococo-autotest:test` *(fails: Could not resolve dependencies, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7207787588327bf280ceaf0aee820