### PR TITLE
Parameterize Selenoid network name

### DIFF
--- a/docker-compose-e2e.sh
+++ b/docker-compose-e2e.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source ./docker.properties
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}" 
 export COMPOSE_PROFILES=test
 export PROFILE=docker
 export PREFIX="${IMAGE_PREFIX}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
     environment:
       - TZ=Europe/Moscow
     restart: unless-stopped
-    command: [ "-conf", "/etc/selenoid/browsers.json", "-limit", "3", "-video-output-dir", "/opt/selenoid/video", "-log-output-dir", "/opt/selenoid/logs", "-container-network", "rococo-master_rococo-network" ]
+    command: [ "-conf", "/etc/selenoid/browsers.json", "-limit", "3", "-video-output-dir", "/opt/selenoid/video", "-log-output-dir", "/opt/selenoid/logs", "-container-network", "${COMPOSE_PROJECT_NAME:-rococo}_rococo-network" ]
     ports:
       - 4444:4444
     networks:


### PR DESCRIPTION
## Summary
- make Selenoid use dynamic network name based on COMPOSE_PROJECT_NAME
- export COMPOSE_PROJECT_NAME in docker-compose-e2e.sh

## Testing
- `bash -n docker-compose-e2e.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b737a210dc832798cde57b249907ff