### PR TITLE
Run isolated tests first

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/IsolatedFirstClassOrderer.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/IsolatedFirstClassOrderer.java
@@ -1,0 +1,31 @@
+package timofeyqa.rococo.jupiter.extension;
+
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.util.Comparator;
+
+/**
+ * Ensures that test classes annotated with {@link Isolated} are executed before
+ * all other classes. Within each group, classes are ordered by the
+ * {@link Order} annotation when present.
+ */
+public class IsolatedFirstClassOrderer implements ClassOrderer {
+
+  @Override
+  public void orderClasses(ClassOrdererContext context) {
+    context.getClassDescriptors().sort(
+        Comparator
+            .comparing((ClassDescriptor cd) ->
+                AnnotationSupport.isAnnotated(cd.getTestClass(), Isolated.class) ? 0 : 1)
+            .thenComparing(cd ->
+                AnnotationSupport.findAnnotation(cd.getTestClass(), Order.class)
+                    .map(Order::value)
+                    .orElse(Order.DEFAULT))
+    );
+  }
+}

--- a/rococo-autotest/src/test/resources/junit-platform.properties
+++ b/rococo-autotest/src/test/resources/junit-platform.properties
@@ -4,4 +4,4 @@ junit.jupiter.execution.parallel.mode.classes.default=concurrent
 junit.jupiter.execution.parallel.config.strategy=fixed
 junit.jupiter.execution.parallel.config.fixed.parallelism=2
 junit.jupiter.execution.parallel.config.fixed.max-pool-size=2
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+junit.jupiter.testclass.order.default=timofeyqa.rococo.jupiter.extension.IsolatedFirstClassOrderer


### PR DESCRIPTION
## Summary
- ensure classes annotated with `@Isolated` run before others by adding a custom JUnit `ClassOrderer`
- configure JUnit Platform to use the new orderer

## Testing
- `gradle :rococo-autotest:test --tests "timofeyqa.rococo.test.web.EmptyListTest" --tests "timofeyqa.rococo.test.web.HeaderTest" --info` *(failed: Could not resolve dependencies, received HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b73e9329888327bee902a471e29521