### PR TITLE
Skip missing backend logs in Allure extension

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/AllureBackendLogsExtension.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/AllureBackendLogsExtension.java
@@ -42,20 +42,22 @@ public class AllureBackendLogsExtension implements SuiteExtension {
 
 
     private static void logAttachment(String serviceName, AllureLifecycle allureLifecycle) {
-        String name = String.format("Rococo-%s log",serviceName);
-        String path = String.format("./logs/rococo_%s/app.log",serviceName);
+        String name = String.format("Rococo-%s log", serviceName);
+        Path path = Path.of(String.format("./logs/rococo_%s/app.log", serviceName));
 
-        try {
+        if (Files.notExists(path)) {
+            return;
+        }
+
+        try (var input = Files.newInputStream(path)) {
             allureLifecycle.addAttachment(
                 name,
                 "text/html",
                 ".log",
-                Files.newInputStream(
-                    Path.of(path)
-                )
+                input
             );
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            System.err.printf("Could not attach log for service %s: %s%n", serviceName, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid RuntimeException when backend log files are absent
- gracefully skip missing logs in AllureBackendLogsExtension

## Testing
- `./gradlew rococo-autotest:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*


------
https://chatgpt.com/codex/tasks/task_e_68b75c8632448327a67cd8c03de2e5a7