### PR TITLE
Mask long request and response bodies

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/api/core/RestClient.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/api/core/RestClient.java
@@ -9,7 +9,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
-import static timofeyqa.rococo.utils.LogUtils.maskLongParams;
+import timofeyqa.rococo.utils.LogUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -48,8 +48,9 @@ public abstract class RestClient implements RequestExecutor {
             }
         }
 
+        LogUtils logUtils = new LogUtils();
         builder.addNetworkInterceptor(new HttpLoggingInterceptor(
-                message -> System.out.println(maskLongParams(message))
+                message -> System.out.println(logUtils.maskLongParams(message))
         ).setLevel(level));
         builder.addNetworkInterceptor(
                 new AllureOkHttp3()

--- a/rococo-autotest/src/test/java/timofeyqa/rococo/utils/GrpcConsoleInterceptor.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/utils/GrpcConsoleInterceptor.java
@@ -7,13 +7,14 @@ import io.grpc.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static timofeyqa.rococo.utils.LogUtils.maskLongParams;
+import timofeyqa.rococo.utils.LogUtils;
 
 @SuppressWarnings("unchecked")
 public class GrpcConsoleInterceptor implements ClientInterceptor {
 
     private static final JsonFormat.Printer printer = JsonFormat.printer();
     private static final Logger LOG = LoggerFactory.getLogger(GrpcConsoleInterceptor.class);
+    private static final LogUtils LOG_UTILS = new LogUtils();
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -24,7 +25,7 @@ public class GrpcConsoleInterceptor implements ClientInterceptor {
             @Override
             public void sendMessage(Object message) {
                 try {
-                    LOG.debug("REQUEST: {}",maskLongParams(printer.print((MessageOrBuilder) message)));
+                    LOG.debug("REQUEST: {}",LOG_UTILS.maskLongParams(printer.print((MessageOrBuilder) message)));
                 } catch (InvalidProtocolBufferException e) {
                     throw new RuntimeException(e);
                 }
@@ -37,7 +38,7 @@ public class GrpcConsoleInterceptor implements ClientInterceptor {
                     @Override
                     public void onMessage(Object message) {
                         try {
-                            LOG.debug("RESPONSE: {}",maskLongParams(printer.print((MessageOrBuilder) message)));
+                            LOG.debug("RESPONSE: {}",LOG_UTILS.maskLongParams(printer.print((MessageOrBuilder) message)));
                         } catch (InvalidProtocolBufferException e) {
                             throw new RuntimeException(e);
                         }

--- a/rococo-autotest/src/test/resources/tpl/http-request.ftl
+++ b/rococo-autotest/src/test/resources/tpl/http-request.ftl
@@ -29,8 +29,7 @@
     <h4>Body</h4>
     <div>
         <#assign bodyStr = data.body?string>
-        <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?static>
-
+        <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?new()>
         <pre><code>${LogUtils.maskLongParams(bodyStr)}</code></pre>
     </div>
 </#if>

--- a/rococo-autotest/src/test/resources/tpl/http-response.ftl
+++ b/rococo-autotest/src/test/resources/tpl/http-response.ftl
@@ -45,7 +45,7 @@
     <h4>Body</h4>
     <div>
         <#assign bodyStr = data.body?string>
-        <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?static>
+        <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?new()>
 
         <pre><code>${LogUtils.maskLongParams(bodyStr)}</code></pre>
     </div>


### PR DESCRIPTION
## Summary
- Mask oversized HTTP request bodies in Allure template using a Freemarker-constructed `LogUtils` instance
- Apply same masking to HTTP response templates and convert `LogUtils` to instantiable class for reuse
- Limit masking to `content`, `avatar` and `photo` fields longer than 2010 characters

## Testing
- `bash gradlew :rococo-autotest:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b75f6b024c832788f69941660ddbb5