### PR TITLE
Enable LogUtils in FreeMarker templates

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/utils/LogUtils.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/utils/LogUtils.java
@@ -3,17 +3,31 @@ package timofeyqa.rococo.utils;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class LogUtils {
+/**
+ * Utility to mask long parameters in logged requests/responses.
+ *
+ * <p>Implements {@link TemplateMethodModelEx} so it can be directly
+ * instantiated and used inside FreeMarker templates.</p>
+ */
+public class LogUtils implements TemplateMethodModelEx {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final int MAX_LENGTH = 2010;
     private static final Set<String> SENSITIVE_KEYS = Set.of("content", "avatar", "photo");
 
+    /**
+     * Masks sensitive long parameters in the provided string.
+     *
+     * @param body original body
+     * @return body with long parameters replaced with &lt;long_param&gt;
+     */
     public String maskLongParams(String body) {
         if (body == null || body.isEmpty()) {
             return body;
@@ -54,5 +68,15 @@ public class LogUtils {
             }
         }
         return modified;
+    }
+
+    @Override
+    public Object exec(List arguments) throws TemplateModelException {
+        if (arguments == null || arguments.isEmpty()) {
+            return "";
+        }
+        Object arg = arguments.get(0);
+        String body = arg == null ? null : arg.toString();
+        return maskLongParams(body);
     }
 }

--- a/rococo-autotest/src/test/resources/tpl/http-request.ftl
+++ b/rococo-autotest/src/test/resources/tpl/http-request.ftl
@@ -30,7 +30,7 @@
     <div>
         <#assign bodyStr = data.body?string>
         <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?new()>
-        <pre><code>${LogUtils.maskLongParams(bodyStr)}</code></pre>
+        <pre><code>${LogUtils(bodyStr)}</code></pre>
     </div>
 </#if>
 

--- a/rococo-autotest/src/test/resources/tpl/http-response.ftl
+++ b/rococo-autotest/src/test/resources/tpl/http-response.ftl
@@ -47,7 +47,7 @@
         <#assign bodyStr = data.body?string>
         <#assign LogUtils = "timofeyqa.rococo.utils.LogUtils"?new()>
 
-        <pre><code>${LogUtils.maskLongParams(bodyStr)}</code></pre>
+        <pre><code>${LogUtils(bodyStr)}</code></pre>
     </div>
 </#if>
 


### PR DESCRIPTION
## Summary
- make LogUtils implement FreeMarker's TemplateMethodModelEx
- use the new LogUtils method in request/response templates

## Testing
- `./gradlew :rococo-autotest:test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b7669e90a083278ba103a96e44810a