### PR TITLE
Ensure screenshot path exists before rewriting expected image

### DIFF
--- a/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/ScreenShotTestExtension.java
+++ b/rococo-autotest/src/test/java/timofeyqa/rococo/jupiter/extension/ScreenShotTestExtension.java
@@ -76,11 +76,12 @@ public class ScreenShotTestExtension implements ParameterResolver, TestExecution
     private static void rewriteExpectedImage(ScreenShotTest screenShotTest) throws IOException {
         final BufferedImage actual = getActual();
         if (actual != null) {
-            ImageIO.write(
-                    actual,
-                    "png",
-                    new File(".screen-output/" + CFG.screenshotBaseDir()  + screenShotTest.value())
-            );
+            File outputFile = new File(".screen-output/" + CFG.screenshotBaseDir() + screenShotTest.value());
+            File parentDir = outputFile.getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                parentDir.mkdirs();
+            }
+            ImageIO.write(actual, "png", outputFile);
         }
     }
 


### PR DESCRIPTION
## Summary
- Create parent directories before saving rewritten screenshots to avoid FileNotFoundException during tests

## Testing
- `./gradlew :rococo-autotest:test` *(fails: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b85648ea348327919f76e7e8b0ac07