### PR TITLE
Add wrapper task to kafka log module

### DIFF
--- a/rococo-kafka-log/build.gradle
+++ b/rococo-kafka-log/build.gradle
@@ -71,3 +71,6 @@ tasks.register('printVersion') {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// Allow running the Gradle Wrapper task from this subproject
+tasks.register('wrapper', Wrapper)


### PR DESCRIPTION
## Summary
- add Gradle Wrapper task to `rococo-kafka-log` module so the wrapper can be invoked directly in that project

## Testing
- `gradle wrapper --console=plain`
- `gradle build --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c1947e18bc8327b4d4a3ab074d8ee3