### PR TITLE
Fix kafka-log-service configuration and enum mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,13 +147,15 @@ services:
 
   kafka-logs.rococo.dc:
     container_name: kafka-logs.rococo.dc
-    image: ${PREFIX}/rococo-kafka-logs-docker:latest
+    image: ${PREFIX}/rococo-kafka-log-docker:latest
     ports:
       - 8097:8097
     restart: always
     depends_on:
       rococo-all-db:
         condition: service_healthy
+      kafka:
+        condition: service_started
     networks:
       - rococo-network
 

--- a/rococo-kafka-log/build.gradle
+++ b/rococo-kafka-log/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     runtimeOnly "com.mysql:mysql-connector-j:${project.ext.mysqlDriverVersion}"
     implementation "org.glassfish:jakarta.el:${project.ext.jakartaElVersion}"
     implementation "org.mapstruct:mapstruct:${project.ext.mapstructVersion}"
+    annotationProcessor "org.mapstruct:mapstruct-processor:${project.ext.mapstructVersion}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation "com.h2database:h2:${project.ext.h2Version}"

--- a/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/data/LogEntity.java
+++ b/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/data/LogEntity.java
@@ -17,6 +17,7 @@ public class LogEntity {
   private UUID id;
 
   @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   private Service service;
 
   @Column(nullable = false)

--- a/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/data/Service.java
+++ b/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/data/Service.java
@@ -1,10 +1,25 @@
 package timofeyqa.kafka_log.data;
 
-public enum Service {
-  rococo_auth,rococo_gateway,rococo_museum,rococo_artist,rococo_painting, rococo_userdata, rococo_geo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-  @Override
-  public String toString() {
-    return this.name().replaceAll("_", "-");
+public enum Service {
+  rococo_auth,
+  rococo_gateway,
+  rococo_museum,
+  rococo_artist,
+  rococo_painting,
+  rococo_userdata,
+  rococo_geo;
+
+  @JsonCreator
+  public static Service fromValue(String value) {
+    return Service.valueOf(value.replace("-", "_"));
+  }
+
+  @JsonValue
+  public String toValue() {
+    return this.name().replace("_", "-");
   }
 }
+


### PR DESCRIPTION
## Summary
- fix docker-compose image name for kafka logs service and wait for Kafka to start
- add MapStruct processor and enum JSON mapping for log service field

## Testing
- `bash ./gradlew :rococo-kafka-log:build` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c193f883cc8327b2fabde66c3665a5