### PR TITLE
chore(kafka-log): remove unused dependencies

### DIFF
--- a/rococo-kafka-log/build.gradle
+++ b/rococo-kafka-log/build.gradle
@@ -15,11 +15,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation "org.flywaydb:flyway-core:${project.ext.flywayVersion}"
     implementation "org.flywaydb:flyway-mysql:${project.ext.flywayVersion}"
-    implementation "net.coobird:thumbnailator:${project.ext.thumbnailatorVersion}"
     annotationProcessor "org.projectlombok:lombok:${project.ext.lombokVersion}"
     compileOnly "org.projectlombok:lombok:${project.ext.lombokVersion}"
     runtimeOnly "com.mysql:mysql-connector-j:${project.ext.mysqlDriverVersion}"
-    implementation "org.glassfish:jakarta.el:${project.ext.jakartaElVersion}"
     implementation "org.mapstruct:mapstruct:${project.ext.mapstructVersion}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${project.ext.mapstructVersion}"
 


### PR DESCRIPTION
## Summary
- remove unused dependencies from kafka-log service

## Testing
- `bash gradlew :rococo-kafka-log:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1991de98c83278795468d58827e6f