### PR TITLE
Handle byte payloads in kafka-log consumer

### DIFF
--- a/rococo-geo/src/main/resources/logback-spring.xml
+++ b/rococo-geo/src/main/resources/logback-spring.xml
@@ -19,7 +19,7 @@
         <producerConfig>
             bootstrap.servers=${kafkaBootstrap}
             key.serializer=org.apache.kafka.common.serialization.StringSerializer
-            value.serializer=org.apache.kafka.common.serialization.StringSerializer
+            value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
         </producerConfig>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>{"service":"${serviceName}"}</customFields>

--- a/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/config/RococoKafkaLogConsumerConfiguration.java
+++ b/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/config/RococoKafkaLogConsumerConfiguration.java
@@ -1,5 +1,6 @@
 package timofeyqa.kafka_log.config;
 
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -10,8 +11,6 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.DefaultErrorHandler;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
-import timofeyqa.kafka_log.model.LogJson;
 
 @Configuration
 public class RococoKafkaLogConsumerConfiguration {
@@ -24,19 +23,17 @@ public class RococoKafkaLogConsumerConfiguration {
   }
 
   @Bean
-  public ConsumerFactory<String, LogJson> consumerFactory(SslBundles sslBundles) {
-    final JsonDeserializer<LogJson> jsonDeserializer = new JsonDeserializer<>(LogJson.class);
-    jsonDeserializer.addTrustedPackages("*");
+  public ConsumerFactory<String, byte[]> consumerFactory(SslBundles sslBundles) {
     return new DefaultKafkaConsumerFactory<>(
         kafkaProperties.buildConsumerProperties(sslBundles),
         new StringDeserializer(),
-        jsonDeserializer
+        new ByteArrayDeserializer()
     );
   }
 
   @Bean
-  public ConcurrentKafkaListenerContainerFactory<String, LogJson> kafkaListenerContainerFactory(SslBundles sslBundles) {
-    ConcurrentKafkaListenerContainerFactory<String, LogJson> concurrentKafkaListenerContainerFactory
+  public ConcurrentKafkaListenerContainerFactory<String, byte[]> kafkaListenerContainerFactory(SslBundles sslBundles) {
+    ConcurrentKafkaListenerContainerFactory<String, byte[]> concurrentKafkaListenerContainerFactory
         = new ConcurrentKafkaListenerContainerFactory<>();
     concurrentKafkaListenerContainerFactory.setCommonErrorHandler(new DefaultErrorHandler());
     concurrentKafkaListenerContainerFactory.setConsumerFactory(consumerFactory(sslBundles));

--- a/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/service/KafkaLogsService.java
+++ b/rococo-kafka-log/src/main/java/timofeyqa/kafka_log/service/KafkaLogsService.java
@@ -1,5 +1,9 @@
 package timofeyqa.kafka_log.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -12,18 +16,28 @@ import timofeyqa.kafka_log.model.LogJson;
 @Service
 public class KafkaLogsService {
 
+  private static final Logger log = LoggerFactory.getLogger(KafkaLogsService.class);
+
   private final KafkaLogsRepository kafkaLogsRepository;
   private final LogMapper logMapper;
+  private final ObjectMapper objectMapper;
 
   @Autowired
-  public KafkaLogsService(KafkaLogsRepository kafkaLogsRepository, LogMapper logMapper) {
+  public KafkaLogsService(KafkaLogsRepository kafkaLogsRepository, LogMapper logMapper, ObjectMapper objectMapper) {
     this.kafkaLogsRepository = kafkaLogsRepository;
     this.logMapper = logMapper;
+    this.objectMapper = objectMapper;
   }
 
   @Transactional
   @KafkaListener(topics = "logs", groupId = "logs")
-  public void listener(@Payload LogJson log) {
-    kafkaLogsRepository.save(logMapper.toEntity(log));
+  public void listener(@Payload byte[] payload) {
+    try {
+      LogJson logJson = objectMapper.readValue(payload, LogJson.class);
+      kafkaLogsRepository.save(logMapper.toEntity(logJson));
+    } catch (IOException e) {
+      log.error("Failed to deserialize log payload", e);
+      throw new IllegalArgumentException("Failed to deserialize log payload", e);
+    }
   }
 }

--- a/rococo-kafka-log/src/test/java/timofeyqa/kafka_log/service/KafkaLogsServiceTest.java
+++ b/rococo-kafka-log/src/test/java/timofeyqa/kafka_log/service/KafkaLogsServiceTest.java
@@ -1,5 +1,6 @@
 package timofeyqa.kafka_log.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -27,8 +28,11 @@ class KafkaLogsServiceTest {
   @Autowired
   private KafkaLogsRepository kafkaLogsRepository;
 
+  @Autowired
+  private ObjectMapper objectMapper;
+
   @Test
-  void logShouldBeSavedToDatabase() {
+  void logShouldBeSavedToDatabase() throws Exception {
     LogJson log = new LogJson(
         "rococo-auth",
         "INFO",
@@ -38,7 +42,9 @@ class KafkaLogsServiceTest {
         Instant.now()
     );
 
-    kafkaLogsService.listener(log);
+    byte[] payload = objectMapper.writeValueAsBytes(log);
+
+    kafkaLogsService.listener(payload);
 
     List<LogEntity> all = kafkaLogsRepository.findAll();
     assertThat(all).hasSize(1);


### PR DESCRIPTION
## Summary
- update the Kafka appender configuration to use the byte array value serializer
- update the kafka-log consumer to deserialize byte-array payloads with the shared ObjectMapper

## Testing
- bash ./gradlew :rococo-geo:build *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- bash ./gradlew :rococo-kafka-log:test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68cacf3705f08327b0995035369707e8