### PR TITLE
Ensure museum and painting wait on prerequisites

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,12 @@ services:
     image: ${PREFIX}/rococo-artist-docker:latest
     ports:
       - 8091:8091
+      - 18091:18091
+    healthcheck:
+      test: "wget --spider http://localhost:18091/actuator/health || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 6
     restart: always
     depends_on:
       rococo-all-db:
@@ -119,6 +125,12 @@ services:
     image: ${PREFIX}/rococo-geo-docker:latest
     ports:
       - 8095:8095
+      - 18095:18095
+    healthcheck:
+      test: "wget --spider http://localhost:18095/actuator/health || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 6
     restart: always
     depends_on:
       rococo-all-db:
@@ -133,12 +145,20 @@ services:
     image: ${PREFIX}/rococo-museum-docker:latest
     ports:
       - 8092:8092
+      - 18092:18092
+    healthcheck:
+      test: "wget --spider http://localhost:18092/actuator/health || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 6
     restart: always
     depends_on:
       rococo-all-db:
         condition: service_healthy
       kafka-init:
         condition: service_completed_successfully
+      geo.rococo.dc:
+        condition: service_healthy
     networks:
       - rococo-network
 
@@ -147,12 +167,22 @@ services:
     image: ${PREFIX}/rococo-painting-docker:latest
     ports:
       - 8094:8094
+      - 18094:18094
+    healthcheck:
+      test: "wget --spider http://localhost:18094/actuator/health || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 6
     restart: always
     depends_on:
       rococo-all-db:
         condition: service_healthy
       kafka-init:
         condition: service_completed_successfully
+      artist.rococo.dc:
+        condition: service_healthy
+      museum.rococo.dc:
+        condition: service_healthy
     networks:
       - rococo-network
 

--- a/rococo-artist/build.gradle
+++ b/rococo-artist/build.gradle
@@ -10,8 +10,9 @@ dependencies {
 	implementation project(':rococo-grpc')
 	implementation "net.devh:grpc-server-spring-boot-starter:${project.ext.springGrpcVersion}"
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation "org.springframework.cloud:spring-cloud-starter-vault-config:${project.ext.springVaultVersion}"
 	implementation "org.flywaydb:flyway-core:${project.ext.flywayVersion}"
@@ -36,7 +37,7 @@ dependencies {
 
 jib {
 	container {
-		ports = ['8091']
+                ports = ['8091', '18091']
 		jvmFlags = ["-Dspring.profiles.active=${System.env.PROFILE}"]
 		environment = [
 				'VAULT_TOKEN': "${System.env.VAULT_TOKEN}".toString(),

--- a/rococo-artist/src/main/resources/application.yaml
+++ b/rococo-artist/src/main/resources/application.yaml
@@ -3,6 +3,18 @@ grpc:
     max-inbound-message-size: 15728640
     port: 8091
 
+management:
+  server:
+    port: 18091
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health
+
 spring:
   application:
     name: rococo-artist

--- a/rococo-geo/build.gradle
+++ b/rococo-geo/build.gradle
@@ -10,8 +10,9 @@ dependencies {
 	implementation project(':rococo-grpc')
 	implementation "net.devh:grpc-server-spring-boot-starter:${project.ext.springGrpcVersion}"
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation "org.springframework.cloud:spring-cloud-starter-vault-config:${project.ext.springVaultVersion}"
 	implementation "org.flywaydb:flyway-core:${project.ext.flywayVersion}"
@@ -32,7 +33,7 @@ dependencies {
 
 jib {
 	container {
-		ports = ['8095']
+                ports = ['8095', '18095']
 		jvmFlags = ["-Dspring.profiles.active=${System.env.PROFILE}"]
 		environment = [
 				'VAULT_TOKEN': "${System.env.VAULT_TOKEN}".toString(),

--- a/rococo-geo/src/main/resources/application.yaml
+++ b/rococo-geo/src/main/resources/application.yaml
@@ -2,6 +2,18 @@ grpc:
   server:
     port: 8095
 
+management:
+  server:
+    port: 18095
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health
+
 spring:
   application:
     name: rococo-geo

--- a/rococo-museum/build.gradle
+++ b/rococo-museum/build.gradle
@@ -10,8 +10,9 @@ dependencies {
 	implementation project(':rococo-grpc')
 	implementation "net.devh:grpc-server-spring-boot-starter:${project.ext.springGrpcVersion}"
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation "org.springframework.cloud:spring-cloud-starter-vault-config:${project.ext.springVaultVersion}"
 	implementation "org.flywaydb:flyway-core:${project.ext.flywayVersion}"
@@ -37,7 +38,7 @@ dependencies {
 
 jib {
 	container {
-		ports = ['8092']
+                ports = ['8092', '18092']
 		jvmFlags = ["-Dspring.profiles.active=${System.env.PROFILE}"]
 		environment = [
 				'VAULT_TOKEN': "${System.env.VAULT_TOKEN}".toString(),

--- a/rococo-museum/src/main/resources/application.yaml
+++ b/rococo-museum/src/main/resources/application.yaml
@@ -3,6 +3,18 @@ grpc:
     max-inbound-message-size: 15728640
     port: 8092
 
+management:
+  server:
+    port: 18092
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health
+
 spring:
   application:
     name: rococo-museum

--- a/rococo-painting/build.gradle
+++ b/rococo-painting/build.gradle
@@ -10,8 +10,9 @@ dependencies {
 	implementation project(':rococo-grpc')
 	implementation "net.devh:grpc-server-spring-boot-starter:${project.ext.springGrpcVersion}"
 
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation "org.springframework.cloud:spring-cloud-starter-vault-config:${project.ext.springVaultVersion}"
 	implementation "org.flywaydb:flyway-core:${project.ext.flywayVersion}"
@@ -36,7 +37,7 @@ dependencies {
 
 jib {
 	container {
-		ports = ['8094']
+                ports = ['8094', '18094']
 		jvmFlags = ["-Dspring.profiles.active=${System.env.PROFILE}"]
 		environment = [
 				'VAULT_TOKEN': "${System.env.VAULT_TOKEN}".toString(),

--- a/rococo-painting/src/main/resources/application.yaml
+++ b/rococo-painting/src/main/resources/application.yaml
@@ -3,6 +3,18 @@ grpc:
     max-inbound-message-size: 15728640
     port: 8094
 
+management:
+  server:
+    port: 18094
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health
+
 spring:
   application:
     name: rococo-painting


### PR DESCRIPTION
## Summary
- add Spring Boot actuator to the geo, artist, museum, and painting services and expose dedicated management ports for Docker health checks
- configure management endpoint properties for the gRPC services so Docker health checks can verify readiness
- update docker-compose dependencies so museum waits for geo and painting waits for museum and artist via service health checks

## Testing
- `bash gradlew :rococo-artist:test :rococo-geo:test :rococo-museum:test :rococo-painting:test` *(fails in CI sandbox: Gradle wrapper cannot download distribution because outbound HTTPS is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d18e31215483278163fffd960f2861