### PR TITLE
Ensure gateway waits for painting service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,8 @@ services:
     depends_on:
       auth.rococo.dc:
         condition: service_healthy
+      painting.rococo.dc:
+        condition: service_healthy
     networks:
       - rococo-network
 


### PR DESCRIPTION
## Summary
- add the painting service to gateway depends_on so it waits for a healthy endpoint before starting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1a0018aa88327ac9c5d52bf262a21